### PR TITLE
Replace location instead of assigning it

### DIFF
--- a/assets/iframe.js
+++ b/assets/iframe.js
@@ -2,7 +2,7 @@ var client = ZAFClient.init()
 
 client.on('app.registered', function(context) {
   var settings = context.metadata.settings
-  window.location = (settings.zafSdkSupport) ? buildUrl(window.location.href, settings.iframeURL) : settings.iframeURL
+  window.location.replace((settings.zafSdkSupport) ? buildUrl(window.location.href, settings.iframeURL) : settings.iframeURL)
 })
 
 function buildUrl (currentUrl, newUrl) {


### PR DESCRIPTION
When Iframe app is loaded, it redirects to the provided URL in app’s settings. This, however, pushes a new state into browser’s history. When a user clicks browser’s back button, the browser does not navigate back as user intended. To navigate back, user must double-click the back button.

Steps to reproduce:
1. Set up an Iframe Ticket Sidebar app with a custom “iframe URL” in app’s settings,
2. Navigate to a ticket with open sidebar,
3. Press browser’s back button,
4. The browser does not navigate back.

This prevents pushing a useless state into browser’s history.

More info on `Location.replace()`: https://developer.mozilla.org/en-US/docs/Web/API/Location/replace